### PR TITLE
Prevent CamelCasing the worksheet name when snake_cased

### DIFF
--- a/lib/axlsx/util/serialized_attributes.rb
+++ b/lib/axlsx/util/serialized_attributes.rb
@@ -52,9 +52,18 @@ module Axlsx
     def serialized_attributes(str = '', additional_attributes = {})
       attributes = declared_attributes.merge! additional_attributes
       attributes.each do |key, value|
-        str << "#{Axlsx.camel(key, false)}=\"#{Axlsx.camel(Axlsx.booleanize(value), false)}\" "
+        str << "#{Axlsx.camel(key, false)}=\"#{serialized_value(key, value)}\" "
       end
       str
+    end
+
+    def serialized_value(key, value)
+      # We don't want to camelcase the sheet names if they are snake cased
+      if key == "name" && value.include?("_")
+        value
+      else
+        Axlsx.camel(Axlsx.booleanize(value), false)
+      end
     end
 
     # A hash of instance variables that have been declared with

--- a/lib/axlsx/util/serialized_attributes.rb
+++ b/lib/axlsx/util/serialized_attributes.rb
@@ -58,7 +58,7 @@ module Axlsx
     end
 
     def serialized_value(key, value)
-      # We don't want to camelcase the sheet names if they are snake cased
+      # We don't want to CamelCase the sheet names if they are snake_cased
       if key == "name" && value.include?("_")
         value
       else


### PR DESCRIPTION
## Description
Adds custom logic on the serialising that prevents the string of the name of a worksheet to be CamelCased when it comes with underscore (snake_cased).

## Tested
Pointed cr_ai master to use this version of the gem locally (gem 'axlsx', :path => '/Users/alfonso/repos/axlsx' in the cr_ai gemfile).
And generated xlsx via `rake 'fancy_report_aws:all[enron1,2018-01-06,2018-07-01,8]'` (with use_s3 env_var false)